### PR TITLE
add apt-fast (replacing apt-get)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,8 +4,17 @@ MAINTAINER github/ojgarciab
 # Use the "noninteractive" debconf frontend
 ENV DEBIAN_FRONTEND noninteractive
 
+# apt-fast installer, replace slow apt-get
+RUN echo apt-fast;\
+    apt-get install -y git make \
+    && target=/root/git/apt-fast \
+    && git clone https://github.com/varhub/apt-fast.git -b 1.8.4 $target \
+    && cd $target \
+    && make install \
+    && apt-get clean autoclean
+
 # Add Gazebo, JdeRobot and PCL repositories
-RUN apt-get update && apt-get install -y curl software-properties-common && \
+RUN apt-get update && apt-fast install -y curl software-properties-common && \
   add-apt-repository -y ppa:v-launchpad-jochen-sprickerhof-de/pcl && \
   echo "deb http://packages.osrfoundation.org/gazebo/ubuntu $(lsb_release -cs) main" \
     > /etc/apt/sources.list.d/gazebo-latest.list && \
@@ -14,7 +23,7 @@ RUN apt-get update && apt-get install -y curl software-properties-common && \
   echo "deb-src http://jderobot.org/apt trusty main" >> /etc/apt/sources.list.d/jderobot.list && \
   curl 'http://jderobot.org/apt/jderobot-key.asc' | apt-key add - && \
   sed -i 's/\/archive\.ubuntu\.com/\/es.archive.ubuntu.com/g' /etc/apt/sources.list && \
-  apt-get update && apt-get install -y \
+  apt-get update && apt-fast install -y \
     bash-completion \
     git \
     build-essential \


### PR DESCRIPTION
If you plan to add it often, please use non-headless version:

```
# Copyright (c) 2016
# Author: Victor Arribas <v.arribas.urjc@gmail.com>
# License: GPLv3 <http://www.gnu.org/licenses/gpl-3.0.html>
#
# apt-fast installer, replace slow apt-get
RUN echo apt-fast;\
    apt-get install -y git make \
    && target=/tmp/git/apt-fast \
    && git clone https://github.com/varhub/apt-fast.git -b 1.8.4 $target \
    && cd $target \
    && make install \
    && apt-get clean autoclean
```

Let me know any speed up improvement ;)
